### PR TITLE
feat: don't deauthorize when connecting to Trello

### DIFF
--- a/src/trelloApiHelper.js
+++ b/src/trelloApiHelper.js
@@ -15,6 +15,11 @@ var deferred,
   wrapper,
   slice = [].slice;
 
+// The local storage key must be related to the ticket dependency graph, to avoid conflict with the other
+// apps hosted on https://theodo.github.io/
+// Indeed, local storage keys are shared among apps from the same host (more exactly, among the protocol://host:port combination)
+const tokenStorageKey = 'ticket-dependency-graph-token';
+
 wrapper = function (window, jQuery, opts) {
   var $,
     Trello,
@@ -109,7 +114,7 @@ wrapper = function (window, jQuery, opts) {
     },
     deauthorize: function () {
       token = null;
-      writeStorage('token', token);
+      writeStorage(tokenStorageKey, token);
     },
     authorize: function (userOpts) {
       var k, persistToken, ref, regexToken, scope, v;
@@ -131,12 +136,12 @@ wrapper = function (window, jQuery, opts) {
       regexToken = /[&#]?token=([0-9a-f]{64})/;
       persistToken = function () {
         if (opts.persist && token != null) {
-          return writeStorage('token', token);
+          return writeStorage(tokenStorageKey, token);
         }
       };
       if (opts.persist) {
         if (token == null) {
-          token = readStorage('token');
+          token = readStorage(tokenStorageKey);
         }
       }
       if (token == null) {

--- a/src/trelloHandler.js
+++ b/src/trelloHandler.js
@@ -55,12 +55,6 @@ window.trelloHandler = new Vue({
     },
 
     authorize() {
-      // Deauthorize user access before re-authorizing it.
-      //
-      // This is used to force the user to generate a new token after the API key changed in https://github.com/theodo/ticket-dependency-graph/pull/49
-      // However, deauthorizing before every authorization also lengthen the user flow, adding otherwise unnecessary steps.
-      // Issue to address this: https://github.com/theodo/ticket-dependency-graph/issues/50
-      window.Trello.deauthorize();
       window.Trello.authorize({
         type: 'popup',
         name: 'Ticket Dependency Graph',


### PR DESCRIPTION
Fix https://github.com/theodo/ticket-dependency-graph/issues/50

By changing the local storage key, we ensure the user doesn't use an outdated token that was associated with another API key.